### PR TITLE
feat: switch to latest ZMK based on zephir 4.1

### DIFF
--- a/build_corne.yaml
+++ b/build_corne.yaml
@@ -13,9 +13,9 @@
 #
 ---
 include:
-  - board: nice_nano_v2
-    shield: corne_left nice_view_adapter nice_view_battery
-  - board: nice_nano_v2
-    shield: corne_right nice_view_adapter nice_view_battery
-  - board: nice_nano_v2
+  - board: nice_nano
+    shield: corne_left nice_view_adapter nice_view_press_start
+  - board: nice_nano
+    shield: corne_right nice_view_adapter nice_view_press_start
+  - board: nice_nano
     shield: settings_reset

--- a/config/west.yml
+++ b/config/west.yml
@@ -4,13 +4,20 @@ manifest:
       url-base: https://github.com/zmkfirmware
     - name: infely
       url-base: https://github.com/infely
+    - name: mctechnology17
+      url-base: https://github. com/mctechnology17
+    - name: Ziembski
+      url-base: https://github.com/Ziembski
   projects:
     - name: zmk
       remote: zmkfirmware
-      revision: v0.3.0
-      import: app/west.yml
-    - name: nice-view-battery
-      remote: infely
       revision: main
+      import: app/west.yml
+    # - name: nice-view-battery
+      # remote: infely
+    # - name: zmk-nice-oled
+      # remote: mctechnology17
+    - name: nice-view-press-start
+      remote: Ziembski
   self:
     path: config


### PR DESCRIPTION
ℹ️ With the update to Zephir 4.1 the `nice_nano@2.0.0` is [used by default](https://zmk.dev/blog/2025/12/09/zephyr-4-1#board-revisions). Just use nice_nano` instead of `nice_nano_v2`

🔥 Latest ZMK breaks most libraries (they use LVGL 8 which was raised to 9.3.0)
- https://github.com/infely/nice-view-battery/issues/3
- https://github.com/mctechnology17/zmk-nice-oled/issues/22
- https://github.com/Ziembski/nice-view-press-start/issues/1